### PR TITLE
Add RabbitMQ-based asynchronous order processing

### DIFF
--- a/api-gateway/src/index.ts
+++ b/api-gateway/src/index.ts
@@ -53,6 +53,10 @@ app.use(
     })
 );
 
+app.use(
+  ''
+)
+
 // Fallback for unmatched
 //app.use((_req, res) => res.status(404).json({ error: 'Not found' }));
 

--- a/order-services/controllers/orderController.ts
+++ b/order-services/controllers/orderController.ts
@@ -1,8 +1,60 @@
 import {Request, Response} from 'express';
 import { PrismaClient } from '../generated/prisma';
 import {redis} from '../cache';
+import {connectRabbit} from '../messaging';
+import { v4 as uuidv4 } from 'uuid';
+
 
 const prisma = new PrismaClient();
+
+export async function requestOrder(req: Request, res: Response) {
+  const { userId, productId, quantity } = req.body;
+  if (!userId || !productId || !quantity) {
+    return res.status(400).json({ error: 'Missing parameters' });
+  }
+
+  const requestId = uuidv4();
+  await prisma.orderRequest.create({ data: { requestId } });
+
+  const channel = await connectRabbit();
+
+  // 1) Declare the work queue
+  await channel.assertQueue('order.requests.queue', { durable: true });
+
+  // 2) Enqueue the job—worker will `consume` from the same queue
+  channel.sendToQueue(
+    'order.requests.queue',
+    Buffer.from(JSON.stringify({ requestId, userId, productId, quantity })),
+    { persistent: true }
+  );
+
+  // 3) Tell client where to poll
+  res
+    .status(202)
+    .location(`/orders/requests/${requestId}`)
+    .json({ requestId, status: 'pending' });
+}
+
+
+export async function getRequestStatus(req:Request, res: Response) {
+    const {requestId} = req.params;
+    const rec = await prisma.orderRequest.findUnique({
+        where: {requestId},
+    });
+    if (!rec) {
+        return res.status(404).json({error: 'Unknown requestId'});
+    }
+    if (!rec.orderId) {
+        return res.json({requestId, status: 'pending'})
+    }
+    // once completed, return the full order
+    const order = await prisma.order.findUnique({
+        where: {id: rec.orderId},
+        include: { products: true},
+    })
+    return res.json({requestId, status: 'complete', order});
+}
+
 
 export async function getAllOrders (req: Request, res: Response) {
     try {
@@ -29,36 +81,95 @@ export async function getOrderById (req: Request, res: Response) {
     
 }
 
-export async function createOrder(req: Request, res: Response) {
-    const {userId, productId, quantity} = req.body;
 
-      // 1. validate user exists
+// const { PRODUCT_URL = 'http://localhost:3001' } = process.env;
 
-    const userRes = await fetch(`http://localhost:3002/${userId}`)
-    if (!userRes.ok) return res.status(404).json({error:'User not found'})
+// export async function createOrder(req: Request, res: Response) {
+//   try {
+//     const { userId, productId, quantity } = req.body;
+//     if (!userId || !productId || !quantity) {
+//       return res.status(400).json({ error: 'Missing parameters' });
+//     }
 
-    // 2. Fetch
-    const prodRes = await fetch(`http://localhost:3001/${productId}`)
-    if (!prodRes.ok) return res.status(404).json({error:'Product not found'});
-    const product = await prodRes.json();
+//     // 1) Fetch latest price from product-service via HTTP
+//     const prodRes = await fetch(`${PRODUCT_URL}/${productId}`);
+//     if (!prodRes.ok) {
+//       return res.status(prodRes.status).json({ error: 'Product not found' });
+//     }
+//     const product = await prodRes.json() as { price: number };
 
-    // 3. Compute total
-    const total = product.price  * quantity
+//     // 2) Compute total and write order in one go
+//     const total = product.price * quantity;
+//     const order = await prisma.order.create({
+//       data: {
+//         userId,
+//         total,
+//         products: { create: [{ productId, quantity }] }
+//       },
+//       include: { products: true },
+//     });
 
-    // 4. save order
-    const order = await prisma.order.create({
-        data: {
-            userId,
-            total,
-            products: {create: [{productId, quantity}]},
-        },
-        include: {products: true},
-    })
+//     // 3) Invalidate order-service Redis caches
+//     await redis.del('GET:/orders');
+//     await redis.del(`GET:/orders/${order.id}`);
 
-        // Invalidate caches:
-    await redis.del('GET:/');             // list cache
-    await redis.del(`GET:/${order.id}`);        // single‐item cache (service mounted at '/')
+//     // 4) Publish `order.created` event to RabbitMQ
+//     const channel = await connectRabbit();
+//     await channel.assertExchange('order.events', 'fanout', { durable: true });
+//     channel.publish(
+//       'order.events',
+//       '',
+//       Buffer.from(JSON.stringify({
+//         orderId: order.id,
+//         userId:  order.userId,
+//         items:   order.products.map(p => ({
+//           productId: p.productId,
+//           quantity:  p.quantity
+//         }))
+//       })),
+//       { persistent: true }
+//     );
+
+//     // 5) Send back the newly created order (with computed `total`)
+//     return res.status(201).json(order);
+
+//   } catch (err) {
+//     console.error('createOrder error', err);
+//     return res.status(500).json({ error: 'Internal server error' });
+//   }
+// }
+
+// function before RabittMQ
+// export async function createOrder(req: Request, res: Response) {
+//     const {userId, productId, quantity} = req.body;
+
+//       // 1. validate user exists
+
+//     const userRes = await fetch(`http://localhost:3002/${userId}`)
+//     if (!userRes.ok) return res.status(404).json({error:'User not found'})
+
+//     // 2. Fetch
+//     const prodRes = await fetch(`http://localhost:3001/${productId}`)
+//     if (!prodRes.ok) return res.status(404).json({error:'Product not found'});
+//     const product = await prodRes.json();
+
+//     // 3. Compute total
+//     const total = product.price  * quantity
+
+//     // 4. save order
+//     const order = await prisma.order.create({
+//         data: {
+//             userId,
+//             total,
+//             products: {create: [{productId, quantity}]},
+//         },
+//         include: {products: true},
+//     })
+
+//         // Invalidate caches:
+//     await redis.del('GET:/');             // list cache
+//     await redis.del(`GET:/${order.id}`);        // single‐item cache (service mounted at '/')
 
 
-    res.status(201).json(order);
-}
+//     res.status(201).json(order);
+// }

--- a/order-services/index.ts
+++ b/order-services/index.ts
@@ -1,14 +1,29 @@
 import express from 'express';
 import orderRouter from './routes/orderRouter';
+import dotenv from 'dotenv';
+import './orderProcessor';  // fire up the background consumer
 
+import { connectRabbit } from './messaging';
+
+dotenv.config();
+
+async function start() {
+    // 1) Establish Rabbit connection
+    await connectRabbit();
+
+    // 2 Start Express
 const app = express();
-
 app.use(express.json());
-
 app.use('/', orderRouter);
 
 const PORT = 3003;
-
 app.listen(PORT, () => {
     console.log(`Listening on port ${PORT}`)
 })
+}
+
+start().catch(err => {
+    console.error('Failed to start order-service', err);
+    process.exit(1);
+})
+

--- a/order-services/messaging.ts
+++ b/order-services/messaging.ts
@@ -1,0 +1,18 @@
+// messaging.ts
+import amqp, { Channel } from 'amqplib';
+import dotenv from 'dotenv';
+dotenv.config();
+
+const RABBIT_URL = process.env.RABBIT_URL!;
+let channel: Channel;
+
+/**
+ * Connects once to RabbitMQ and returns a channel.
+ * Subsequent calls return the same channel.
+ */
+export async function connectRabbit(): Promise<Channel> {
+  if (channel) return channel;
+  const conn = await amqp.connect(RABBIT_URL);
+  channel = await conn.createChannel();
+  return channel;
+}

--- a/order-services/orderProcessor.ts
+++ b/order-services/orderProcessor.ts
@@ -1,0 +1,82 @@
+import { PrismaClient } from './generated/prisma';
+import { connectRabbit } from './messaging';
+
+const prisma = new PrismaClient();
+
+const PRODUCT_URL = process.env.PRODUCT_URL!; // e.g. http://localhost:3001
+
+async function startWorker() {
+  // 1) Get your RabbitMQ channel
+  const channel = await connectRabbit();
+
+  // 2) Declare the queue that *will* receive those requests
+  await channel.assertQueue('order.requests.queue', { durable: true });
+
+  // 3) Fair‐dispatch: one unacked message at a time
+  channel.prefetch(1);
+
+  // 4) Start consuming from the now‐bound queue
+  channel.consume('order.requests.queue', async msg => {
+    if (!msg) return;
+    const { requestId, userId, productId, quantity } =
+      JSON.parse(msg.content.toString());
+
+    try {
+      // 5a) Fetch price
+      const resp = await fetch(`${PRODUCT_URL}/${productId}`);
+      if (!resp.ok) throw new Error('Product not found');
+      const product = (await resp.json()) as { price: number };
+      const total = product.price * quantity;
+
+      // 5b) Persist the order
+      const order = await prisma.order.create({
+        data: {
+          userId,
+          total,
+          products: { create: [{ productId, quantity }] }
+        },
+        include: { products: true },
+      });
+
+      // 5c) Mark the original request as complete
+      await prisma.orderRequest.update({
+        where: { requestId },
+        data: { orderId: order.id }
+      });
+
+      // 5d) Emit the order.created event for downstream services
+      await channel.assertExchange('order.events','fanout',{ durable: true });
+      channel.publish(
+        'order.events',
+        '',
+        Buffer.from(JSON.stringify({
+          orderId: order.id,
+          userId:  order.userId,
+          items:   order.products.map(p => ({
+            productId: p.productId,
+            quantity:  p.quantity
+          }))
+        })),
+        { persistent: true }
+      );
+
+      // 5e) Acknowledge so RabbitMQ can remove this message
+      channel.ack(msg);
+
+    } catch (err) {
+      console.error(`Failed to process request ${requestId}:`, err);
+      // Even on error, ack to avoid infinite redelivery;
+      // you could nack(msg, false, true) to requeue if you prefer retries.
+      channel.ack(msg);
+    }
+  });
+
+  console.log('Order-processor worker started');
+}
+
+startWorker().catch(err => {
+  console.error('Order-processor crashed', err);
+  process.exit(1);
+});
+
+

--- a/order-services/package-lock.json
+++ b/order-services/package-lock.json
@@ -10,9 +10,11 @@
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^6.10.0",
+        "amqplib": "^0.10.8",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
-        "redis": "^5.5.6"
+        "redis": "^5.5.6",
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "@faker-js/faker": "^9.8.0",
@@ -727,6 +729,19 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/amqplib": {
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.10.8.tgz",
+      "integrity": "sha512-Tfn1O9sFgAP8DqeMEpt2IacsVTENBpblB3SqLdn0jK2AeX8iyCvbptBc8lyATT9bQ31MsjVwUSQ1g8f4jHOUfw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-more-ints": "~1.0.0",
+        "url-parse": "~1.5.10"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
@@ -746,6 +761,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/buffer-more-ints": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz",
+      "integrity": "sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg==",
+      "license": "MIT"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -1412,6 +1433,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -1451,6 +1478,12 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
@@ -1699,6 +1732,29 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/order-services/package.json
+++ b/order-services/package.json
@@ -20,8 +20,10 @@
   },
   "dependencies": {
     "@prisma/client": "^6.10.0",
+    "amqplib": "^0.10.8",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
-    "redis": "^5.5.6"
+    "redis": "^5.5.6",
+    "uuid": "^11.1.0"
   }
 }

--- a/order-services/prisma/migrations/20250624074400_add_order_request/migration.sql
+++ b/order-services/prisma/migrations/20250624074400_add_order_request/migration.sql
@@ -1,0 +1,13 @@
+-- CreateTable
+CREATE TABLE "OrderRequest" (
+    "id" SERIAL NOT NULL,
+    "requestId" TEXT NOT NULL,
+    "orderId" INTEGER,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "OrderRequest_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "OrderRequest_requestId_key" ON "OrderRequest"("requestId");

--- a/order-services/prisma/schema.prisma
+++ b/order-services/prisma/schema.prisma
@@ -14,6 +14,15 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+model OrderRequest {
+  id         Int      @id @default(autoincrement())
+  requestId  String   @unique
+  orderId    Int?     // filled once the worker completes
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+}
+
+
 model Order {
   id         Int      @id @default(autoincrement())
   createdAt  DateTime @default(now())

--- a/order-services/routes/orderRouter.ts
+++ b/order-services/routes/orderRouter.ts
@@ -1,12 +1,14 @@
 import {Router} from 'express';
-import {getAllOrders, createOrder, getOrderById} from '../controllers/orderController';
+import {getAllOrders, requestOrder, getRequestStatus, getOrderById} from '../controllers/orderController';
 import {cache} from '../middlewares/cache'
 
 const orderRouter = Router();
 
 orderRouter.get('/', cache(60), getAllOrders);
 orderRouter.get('/:orderId', cache(60), getOrderById)
-orderRouter.post('/', createOrder);
+orderRouter.post('/', requestOrder);
+orderRouter.get('/requests/:requestId', getRequestStatus);
+
 
 export default orderRouter;
 

--- a/product-service/index.ts
+++ b/product-service/index.ts
@@ -1,16 +1,53 @@
 import express from 'express';
 import productRouter from "./routes/productRouter";
 import './cache';                   // ← <-- this runs cache.ts top–level code
+import dotenv from 'dotenv';
+import { PrismaClient } from './generated/prisma';
+import {connectRabbit} from './messaging'
 
-const app = express();
+const prisma = new PrismaClient()
 
-app.use(express.json())
+dotenv.config();
 
-app.use("/", productRouter);
+async function start() {
+    // 1) Start HTTP server
+    const app = express();
+
+    app.use(express.json())
+
+    app.use("/", productRouter);
 
 
-const PORT = 3001;
+    const PORT = 3001;
 
-app.listen(PORT, () => {
-    console.log(`Listening on port ${PORT}`)
+    app.listen(PORT, () => {
+        console.log(`Listening on port ${PORT}`)
+    })
+
+    // 2) Then bootstrap Rabbit consumer
+    const channel = await connectRabbit();
+    await channel.assertExchange('order.events', 'fanout', {durable: true});
+    const q = await channel.assertQueue('product-stock-queue', {durable: true});
+
+    // Bind our queue to the exchange so we get every event
+    await channel.bindQueue(q.queue, 'order.events', '');
+
+    //Start consuming
+    channel.consume(q.queue, async msg => {
+        if(!msg) return;
+        const {items} = JSON.parse(msg.content.toString());
+        for (const {productId, quantity} of items) {
+            await prisma.product.update({
+                where: {id: productId},
+                data: {stock: {decrement: quantity}}
+            });
+        }
+        channel.ack(msg);
+    })
+}
+
+start().catch(err => {
+    console.error('Failed to start product-service:', err);
+    process.exit(1);
 })
+

--- a/product-service/messaging.ts
+++ b/product-service/messaging.ts
@@ -1,0 +1,13 @@
+import amqp, { Channel } from 'amqplib';
+import dotenv from 'dotenv';
+dotenv.config();
+
+const RABBIT_URL = process.env.RABBIT_URL!;
+let channel: Channel;
+
+export async function connectRabbit(): Promise<Channel> {
+    if (channel) return channel;
+    const conn = await amqp.connect(RABBIT_URL);
+    channel = await conn.createChannel();
+    return channel;
+}

--- a/product-service/package-lock.json
+++ b/product-service/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^6.10.0",
+        "amqplib": "^0.10.8",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "redis": "^5.5.6"
@@ -727,6 +728,19 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/amqplib": {
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.10.8.tgz",
+      "integrity": "sha512-Tfn1O9sFgAP8DqeMEpt2IacsVTENBpblB3SqLdn0jK2AeX8iyCvbptBc8lyATT9bQ31MsjVwUSQ1g8f4jHOUfw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-more-ints": "~1.0.0",
+        "url-parse": "~1.5.10"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
@@ -746,6 +760,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/buffer-more-ints": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz",
+      "integrity": "sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg==",
+      "license": "MIT"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -1412,6 +1432,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -1451,6 +1477,12 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
@@ -1699,6 +1731,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/vary": {

--- a/product-service/package.json
+++ b/product-service/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@prisma/client": "^6.10.0",
+    "amqplib": "^0.10.8",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "redis": "^5.5.6"


### PR DESCRIPTION
Introduce a RabbitMQ work queue for order requests and a fanout exchange for order.created events. New orders are queued in order.requests.queue and processed by a background worker, enabling non-blocking HTTP endpoints.

This decouples order placement from heavy tasks (price lookup, database writes) and permits horizontal scaling of workers. It also improves fault tolerance: if any service is down, messages persist in the broker. Clients can poll OrderRequest records to track completion.

Product-service now subscribes to order.events to asynchronously decrement stock, separating responsibilities cleanly across services.